### PR TITLE
Fix for Ruby 1.9.2 Syntax Change Problem

### DIFF
--- a/lib/yelp/request.rb
+++ b/lib/yelp/request.rb
@@ -34,8 +34,10 @@ class Yelp
       # if they specified anything other than a json variant, we
       # need to tell yelp what we're looking for
       case @response_format
-      when Yelp::ResponseFormat::PICKLE: params[:output] = 'pickle'
-      when Yelp::ResponseFormat::PHP: params[:output] = 'php'
+      when Yelp::ResponseFormat::PICKLE
+        params[:output] = 'pickle'
+      when Yelp::ResponseFormat::PHP
+        params[:output] = 'php'
       end
 
       params


### PR DESCRIPTION
This case/when syntax is no longer supported in Ruby 1.9.2. Changed it so it should work with any Ruby. See this blog post comment for more info on the Ruby 1.9.2 change that causes it... 

http://blog.grayproductions.net/articles/getting_code_ready_for_ruby_19#comment_1010
