### PR TITLE
added link to RapidAPI

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -116,3 +116,7 @@ This library is provided via the GNU LGPL license at http://www.gnu.org/licenses
 == Authors
 
 Copyright 2007 - 2009, Walter Korman <shaper@fatgoose.com>, http://lemurware.blogspot.com
+
+== API Testing
+
+RapidAPI: https://rapidapi.com/package/YelpAPI/functions?utm_source=YelpGithub&utm_medium=button&utm_content=Vender_GitHub


### PR DESCRIPTION
Hey there. I added a link in your README to a tool where you can test out Yelp API calls in your browser before using your SDK to connect to the API. I've added it to these other SDKs (Telegram, Shopify and LinkedIn) and gotten feedback that it was pretty useful. If anything, let me know what you think and if you have any feedback. I'm part of the team that built this tool and we're always looking to make it better!